### PR TITLE
state?

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ elli_websocket is a websocket handler for Elli: https://github.com/knutin/elli
 ## Installation
 
 You can add elli_websocket to your application by adding it as a dependency to your elli 
-application. At the moment elli_websocket is dependant on a handover and ssl feature and
-needs a specific elli branch.
+application.
 
 ```erlang
 % rebar.config


### PR DESCRIPTION
Is this dead? Why is there no "issues" tab?
I see PRs are being merged "upstream": https://github.com/mmzeeman/elli_websocket/pull/5. Does this mean this project is not maintained at all?
Finally, any plans on fixing:
> At the moment elli_websocket is dependant on a handover and ssl feature and needs a specific elli branch.

Thanks!