### PR TITLE
Replace deprecated crypto:sha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
   directories:
   - $HOME/.cache/rebar3/
 otp_release:
+- 21.0
+- 20.2
 - 19.3
 - 19.0
 - 18.3

--- a/src/elli_ws_protocol.erl
+++ b/src/elli_ws_protocol.erl
@@ -185,8 +185,7 @@ handler_init(State=#state{env=Env, handler=Handler}, Req, HandlerOpts) ->
 %%   | {suspend, module(), atom(), [any()]}
 %%   when Req::elli_ws_request_adapter:req().
 websocket_handshake(State=#state{key=Key, deflate_frame=DeflateFrame, handler=Handler}, Req, HandlerState) ->
-    %% @todo Change into crypto:hash/2 for R17B+ or when supporting only R16B+.
-    Challenge = base64:encode(crypto:sha(
+    Challenge = base64:encode(crypto:hash(sha,
                                 << Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" >>)),
     Extensions = case DeflateFrame of
                      false -> [];

--- a/src/elli_ws_request_adapter.erl
+++ b/src/elli_ws_request_adapter.erl
@@ -208,8 +208,10 @@ websocket_handler_init(#req_adapter{req=Req}=RA, Handler, HandlerOpts) ->
       HandlerState :: any(),
       Result :: {ok, req(), any()} |
                 {ok, req(), any(), hibernate} |
-                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()], req(), any()} |
-                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()], req(), any(), hibernate} |
+                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()],
+                 req(), any()} |
+                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()],
+                 req(), any(), hibernate} |
                 {shutdown, req(), any()}.
 websocket_handler_callback(#req_adapter{req=Req}=RA, Handler, Callback, Message, HandlerState) ->
     case Handler:Callback(Req, Message, HandlerState) of

--- a/src/elli_ws_request_adapter.erl
+++ b/src/elli_ws_request_adapter.erl
@@ -208,8 +208,8 @@ websocket_handler_init(#req_adapter{req=Req}=RA, Handler, HandlerOpts) ->
       HandlerState :: any(),
       Result :: {ok, req(), any()} |
                 {ok, req(), any(), hibernate} |
-                {reply, elli_websocket:payload(), req(), any()} |
-                {reply, elli_websocket:payload(), hibernate, req(), any()} |
+                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()], req(), any()} |
+                {reply, elli_ws_protocol:frame() | [elli_ws_protocol:frame()], req(), any(), hibernate} |
                 {shutdown, req(), any()}.
 websocket_handler_callback(#req_adapter{req=Req}=RA, Handler, Callback, Message, HandlerState) ->
     case Handler:Callback(Req, Message, HandlerState) of


### PR DESCRIPTION
Hi,

the latest version of elli_websocket fails on OTP 21.0 with undefined `crypto:sha`. The function is  deprecated for quite some time now.
AFAIK the proposed change should work for OTP >= 18 at least.

Cheers,
Gregor