### PR TITLE
Update README and example with working close status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,13 @@ handle('websocket', [<<"echo_websocket">>], Req, Args) ->
     %% Upgrade to a websocket connection.
     elli_websocket:upgrade(Req, Args),
 
-    %% websocket is closed.
-    {close, <<>>};
+    %% websocket is closed: 
+    %% See RFC-6455 (https://tools.ietf.org/html/rfc6455) for a list of
+    %% valid WS status codes than can be used on a close frame.
+    %% Note that the second element is the reason and is abitrary but should be meaningful
+    %% in regards to your server and sub-protocol.
+    {<<"1000">>, <<"Closed">>};
+
 handle('GET', [<<"echo_websocket">>], _Req, _Args) ->
     %% We got a normal request, request was not upgraded.
     {200, [], <<"Use an upgrade request">>};

--- a/src/elli_example_websocket.erl
+++ b/src/elli_example_websocket.erl
@@ -55,7 +55,13 @@ init_ws(_, _, _) ->
 
 handle('websocket', [<<"my">>, <<"websocket">>], Req, Args) ->
     elli_websocket:upgrade(Req, Args),
-    {close, <<>>};
+
+    %% websocket is closed:
+    %% See RFC-6455 (https://tools.ietf.org/html/rfc6455) for a list of
+    %% valid WS status codes than can be used on a close frame.
+    %% Note that the second element is the reason and is abitrary but should be meaningful
+    %% in regards to your server and sub-protocol.
+    {<<"1000">>, <<"Closed">>};
 
 handle('GET', [<<"my">>, <<"websocket">>], _Req, _Args) ->
     {200, [], <<"Use an upgrade request">>};


### PR DESCRIPTION
 This PR updates the websocket example and README with a valid close status. Specifically, `close` does not exist in elli_http. Thus, on connection close (from client or server) a no matching function clause exception would happen. 